### PR TITLE
feat: Add user registration, login, and user routes

### DIFF
--- a/src/app/api/login/route.ts
+++ b/src/app/api/login/route.ts
@@ -1,0 +1,39 @@
+import { NextRequest, NextResponse } from "next/server";
+import { createUserClient } from "@/lib/supabase";
+import { corsHeaders, handleOptions } from "@/lib/cors";
+
+export async function OPTIONS(req: NextRequest) {
+  return handleOptions(req.headers.get("origin") || undefined);
+}
+
+export async function POST(req: NextRequest) {
+  const origin = req.headers.get("origin") || undefined;
+  try {
+    const { email, password } = await req.json();
+    if (!email || !password) {
+      return NextResponse.json({ error: "Email and password are required" }, { status: 400, headers: corsHeaders(origin) });
+    }
+
+    // Using createUserClient as we don't need admin rights to log in.
+    // The signInWithPassword function does not depend on user-specific RLS.
+    const supa = createUserClient();
+    const { data, error } = await supa.auth.signInWithPassword({
+      email,
+      password,
+    });
+
+    if (error) {
+      return NextResponse.json({ error: error.message }, { status: 401, headers: corsHeaders(origin) });
+    }
+
+    if (!data.session) {
+        return NextResponse.json({ error: "Login failed, no session" }, { status: 401, headers: corsHeaders(origin) });
+    }
+
+    // Login successful, return the session which contains the JWT access_token.
+    return NextResponse.json({ session: data.session }, { headers: corsHeaders(origin) });
+
+  } catch (error) {
+    return NextResponse.json({ error: "Invalid request body" }, { status: 400, headers: corsHeaders(origin) });
+  }
+}

--- a/src/app/api/register/route.ts
+++ b/src/app/api/register/route.ts
@@ -1,0 +1,39 @@
+import { NextRequest, NextResponse } from "next/server";
+import { createAdminClient } from "@/lib/supabase";
+import { corsHeaders, handleOptions } from "@/lib/cors";
+
+export async function OPTIONS(req: NextRequest) {
+  return handleOptions(req.headers.get("origin") || undefined);
+}
+
+export async function POST(req: NextRequest) {
+  const origin = req.headers.get("origin") || undefined;
+  try {
+    const { email, password } = await req.json();
+    if (!email || !password) {
+      return NextResponse.json({ error: "Email and password are required" }, { status: 400, headers: corsHeaders(origin) });
+    }
+
+    const supa = createAdminClient();
+    const { data, error } = await supa.auth.signUp({
+      email,
+      password,
+    });
+
+    if (error) {
+      return NextResponse.json({ error: error.message }, { status: 400, headers: corsHeaders(origin) });
+    }
+
+    if (!data.user) {
+        return NextResponse.json({ error: "Registration failed" }, { status: 500, headers: corsHeaders(origin) });
+    }
+
+    // The user is created, but needs to verify email.
+    // Supabase sends a confirmation email automatically if enabled.
+    // We do not return a session here. The user must login after verification.
+    return NextResponse.json({ message: "Registration successful, please check your email for verification." }, { headers: corsHeaders(origin) });
+
+  } catch (error) {
+    return NextResponse.json({ error: "Invalid request body" }, { status: 400, headers: corsHeaders(origin) });
+  }
+}

--- a/src/app/api/user/route.ts
+++ b/src/app/api/user/route.ts
@@ -1,0 +1,27 @@
+import { NextRequest, NextResponse } from "next/server";
+import { createUserClient } from "@/lib/supabase";
+import { corsHeaders, handleOptions } from "@/lib/cors";
+
+export async function OPTIONS(req: NextRequest) {
+  return handleOptions(req.headers.get("origin") || undefined);
+}
+
+export async function GET(req: NextRequest) {
+  const origin = req.headers.get("origin") || undefined;
+  const auth = req.headers.get("authorization") || "";
+  const jwt = auth.replace(/Bearer\s+/i, "").trim();
+  if (!jwt) return NextResponse.json({ error: "Unauthorized" }, { status: 401, headers: corsHeaders(origin) });
+
+  const supa = createUserClient(jwt);
+  const { data, error } = await supa.auth.getUser();
+
+  if (error) {
+    return NextResponse.json({ error: error.message }, { status: 401, headers: corsHeaders(origin) });
+  }
+
+  if (!data.user) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401, headers: corsHeaders(origin) });
+  }
+
+  return NextResponse.json({ user: data.user }, { headers: corsHeaders(origin) });
+}


### PR DESCRIPTION
This commit introduces a complete user authentication flow to the API.

- A new `/api/register` route is added to handle user sign-ups using Supabase Auth.
- A new `/api/login` route is added for users to sign in and receive a JWT session token.
- A new `/api/user` route is added to demonstrate a protected endpoint that validates the JWT and returns user data.

The implementation follows the existing project structure and conventions, including CORS handling and the use of Supabase client factories.